### PR TITLE
bug check json

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -13,7 +13,7 @@ export default Task;
 
 export function taskReviver(key: string, value: any): any {
   // We receive and empty key and the whole JSON in value at some point
-  if (key === "") {
+  if (key === "" && value.isArray) {
     return value;
   }
 


### PR DESCRIPTION
if the json is not an array the program bugs.
si le JSON est :
```
{
    "id": 1,
    "task": "je suis une super tache",
    "done": false
}
```

you will have an error on the map function. Indeed, the key will first have the value id, then task, then done and finally the key will be empty, which will return the object without error.  When you want to browse the tasks with the map function, you will get an error because the object returned is not an array.